### PR TITLE
Added functionality to delete a tag with confirmation window

### DIFF
--- a/src/Rare.js
+++ b/src/Rare.js
@@ -4,26 +4,17 @@ import { NavBar } from "./components/nav/NavBar";
 
 export const Rare = () => {
   const [token, setTokenState] = useState(localStorage.getItem("auth_token"));
-  const [staff, setStaffState] = useState(false);
+  const staff = localStorage.getItem("staff");
 
   const setToken = (newToken) => {
     localStorage.setItem("auth_token", newToken);
     setTokenState(newToken);
   };
 
-  const setStaff = (boolean) => {
-    setStaffState(boolean);
-  };
-
   return (
     <>
       <NavBar token={token} setToken={setToken} />
-      <ApplicationViews
-        token={token}
-        setToken={setToken}
-        staff={staff}
-        setStaff={setStaff}
-      />
+      <ApplicationViews token={token} setToken={setToken} staff={staff} />
     </>
   );
 };

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { loginUser } from "../../managers/AuthManager";
 
-export const Login = ({ setToken, setStaff }) => {
+export const Login = ({ setToken }) => {
   const username = useRef();
   const password = useRef();
   const navigate = useNavigate();
@@ -19,7 +19,7 @@ export const Login = ({ setToken, setStaff }) => {
     loginUser(user).then((res) => {
       if ("valid" in res && res.valid) {
         setToken(res.token);
-        setStaff(res.staff);
+        localStorage.setItem("staff", res.staff);
         navigate("/");
       } else {
         setisUnsuccessful(true);

--- a/src/components/tags/TagList.js
+++ b/src/components/tags/TagList.js
@@ -1,15 +1,19 @@
 import { useEffect, useState } from "react";
-import { getAllTags } from "../../managers/TagManager";
+import { deleteTag, getAllTags } from "../../managers/TagManager";
 import "./Tag.css";
 
 export const TagList = ({ token, staff }) => {
   const [tags, setTags] = useState([]);
 
-  useEffect(() => {
+  const retrieveTags = () => {
     getAllTags(token).then((tagArr) => {
       setTags(tagArr);
     });
-  }, [token]);
+  };
+
+  useEffect(() => {
+    retrieveTags();
+  }, []);
 
   const displayTags = () => {
     if (tags && tags.length) {
@@ -18,13 +22,13 @@ export const TagList = ({ token, staff }) => {
           {staff ? (
             <>
               <div className="tag--item">
-                <i
-                  className="fa-solid fa-gear fa-lg"
-                  onClick={() => handleDelete(tag.id)}
-                ></i>
+                <i className="fa-solid fa-gear fa-lg"></i>
               </div>
               <div className="tag--item">
-                <i className="fa-solid fa-trash-can fa-lg"></i>
+                <i
+                  className="fa-solid fa-trash-can fa-lg"
+                  onClick={() => handleDelete(tag.id)}
+                ></i>
               </div>
             </>
           ) : (
@@ -40,6 +44,11 @@ export const TagList = ({ token, staff }) => {
     const confirmDelete = window.confirm(
       "Are you sure you want to delete tag?"
     );
+    if (confirmDelete) {
+      deleteTag(token, tagId).then(() => {
+        retrieveTags();
+      });
+    }
   };
 
   return (

--- a/src/components/tags/TagList.js
+++ b/src/components/tags/TagList.js
@@ -18,7 +18,10 @@ export const TagList = ({ token, staff }) => {
           {staff ? (
             <>
               <div className="tag--item">
-                <i className="fa-solid fa-gear fa-lg"></i>
+                <i
+                  className="fa-solid fa-gear fa-lg"
+                  onClick={() => handleDelete(tag.id)}
+                ></i>
               </div>
               <div className="tag--item">
                 <i className="fa-solid fa-trash-can fa-lg"></i>
@@ -32,6 +35,13 @@ export const TagList = ({ token, staff }) => {
       ));
     }
   };
+
+  const handleDelete = (tagId) => {
+    const confirmDelete = window.confirm(
+      "Are you sure you want to delete tag?"
+    );
+  };
+
   return (
     <article>
       <h2>Tags</h2>

--- a/src/managers/AuthManager.js
+++ b/src/managers/AuthManager.js
@@ -13,7 +13,7 @@ export const loginUser = (user) => {
 };
 
 export const registerUser = (newUser) => {
-  return fetch("http://localhost:8088/register", {
+  return fetch("http://localhost:8000/register", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/managers/TagManager.js
+++ b/src/managers/TagManager.js
@@ -5,3 +5,12 @@ export const getAllTags = (token) => {
     },
   }).then((res) => res.json());
 };
+
+export const deleteTag = (token, tagId) => {
+  return fetch(`http://localhost:8000/tags/${tagId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Token ${token}`,
+    },
+  });
+};


### PR DESCRIPTION
I updated Tag View to include the ability to delete a tag as an admin.

## Steps to Test
1. Pull down `ts-delete-tag` branch and switch to it and that your debugger is running
2. Be sure to pull down `ts-tag-destroy` on the server side
3. Login with the following credentials
```
{
        "username": "phifertristan",
        "password": "phifer"
}
```
4. Click on Tag Manager on navbar...should take you to `http://localhost:3000/tags`
5. You should see a gear icon and a trash icon next to each tag
6. Click on a trash icon and you should see a window confirmation appear
7. Click on cancel and you should return to the page with all the tags still listed
8. Click on a trash icon again but this time click okay, you should return to the page but the tag you just deleted should no longer appear in the list
9. In the network tab you should be receiving a 204 status code for the delete and a 200 for the re-rendering of the page.

closes #18 