### PR TITLE
Category DELETE request and staff buttons

### DIFF
--- a/src/components/categories/CategoriesList.js
+++ b/src/components/categories/CategoriesList.js
@@ -1,16 +1,33 @@
 import { useNavigate } from "react-router-dom";
-import { getAllCategories } from "../../managers/CategoryManager";
+import { deleteCategory, getAllCategories } from "../../managers/CategoryManager";
 import { useEffect, useState } from "react";
 
-export const CategoriesList = ({token}) => {
+export const CategoriesList = ({token, staff}) => {
   const [categories, setCategories] = useState([])
   const navigate = useNavigate();
+
+  const fetchCategories = () => {
+    getAllCategories(token).then((catArray) => {
+      setCategories(catArray)
+    })
+  }
 
   useEffect(() => {
     getAllCategories(token).then((categoryArray) => {
       setCategories(categoryArray)
     })
   }, [token])
+
+  const handleDelete = (categoryId) => {
+    const confirmDelete = window.confirm(
+      "Are you sure you want to remove this category?"
+    );
+    if(confirmDelete) {
+      deleteCategory(token, categoryId).then(() => {
+        fetchCategories()
+      })
+    }
+  }
 
   return (
     <>
@@ -19,9 +36,22 @@ export const CategoriesList = ({token}) => {
         <div>
           <ul>
             {categories.map((category) => (
-              <li key={category.id}>
-                <h3>{category.label}</h3>
-              </li>
+              <div className="category--container" key={category.id}>
+                { staff ? (
+                  <>
+                    <div className="category--item">
+                      <i className="fa-solid fa-gear fa-lg"></i>
+                    </div>
+                    <div className="category--item">
+                      <i className="fa-solid fa-trash-can fa-lg"
+                      onClick={() => handleDelete(category.id)}></i>
+                    </div>
+                  </>
+                ) : (
+                  ""
+                )}
+                <div className="category--item">{category.label}</div>
+              </div>
             ))}
           </ul>
         </div>

--- a/src/components/categories/CategoriesList.js
+++ b/src/components/categories/CategoriesList.js
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { deleteCategory, getAllCategories } from "../../managers/CategoryManager";
 import { useEffect, useState } from "react";
+import "./Category.css"
 
 export const CategoriesList = ({token, staff}) => {
   const [categories, setCategories] = useState([])

--- a/src/components/categories/Category.css
+++ b/src/components/categories/Category.css
@@ -1,0 +1,12 @@
+.categories--container {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .category--container {
+    display: flex;
+  }
+  
+  .category--item {
+    padding: 0.5rem;
+  }

--- a/src/managers/CategoryManager.js
+++ b/src/managers/CategoryManager.js
@@ -17,3 +17,15 @@ export const createCategory = async (newCategory, token) => {
     body: JSON.stringify(newCategory),
   });
 };
+
+export const deleteCategory = (token, categoryId) => {
+  return (
+    fetch(`http://localhost:8000/categories/${categoryId}`),
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Token ${token}`,
+      },
+    }
+  );
+};

--- a/src/managers/CategoryManager.js
+++ b/src/managers/CategoryManager.js
@@ -19,13 +19,10 @@ export const createCategory = async (newCategory, token) => {
 };
 
 export const deleteCategory = (token, categoryId) => {
-  return (
-    fetch(`http://localhost:8000/categories/${categoryId}`),
-    {
-      method: "DELETE",
-      headers: {
-        Authorization: `Token ${token}`,
-      },
-    }
-  );
+  return fetch(`http://localhost:8000/categories/${categoryId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Token ${token}`,
+    },
+  });
 };

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -20,7 +20,7 @@ export const ApplicationViews = ({ token, setToken, staff, setStaff }) => {
         <Route element={<Authorized token={token} />}>
           <Route path="/" element="Hello" />
           <Route path="/my_posts" element={<MyPosts token={token} />} />
-          <Route path="/categories" element={<CategoriesList token={token}/>} />
+          <Route path="/categories" element={<CategoriesList token={token} staff={staff}/>} />
           <Route
             path="/create_category"
             element={<CategoryForm token={token} />}


### PR DESCRIPTION
I updated Category View to include the ability to delete a tag as an admin.

## Steps to Test
1. Pull down `tp-destroy-category` branch and switch to it and that your debugger is running
2. Be sure to pull down `tp-destroy-category` on the server side
3. Login with the following credentials
```
{
        "username": "phifertristan",
        "password": "phifer"
}
```
4. Click on Category Manager on navbar...should take you to `http://localhost:3000/categories`
5. You should see a gear icon and a trash icon next to each category
6. Click on a trash icon and you should see a window confirmation appear
7. Click on cancel and you should return to the page with all the categories still listed
8. Click on a trash icon again but this time click okay, you should return to the page but the category you just deleted should no longer appear in the list
9. In the network tab you should be receiving a 204 status code for the delete and a 200 for the re-rendering of the page.

closes #16 