### PR TITLE
Added delete post functionality on user's own posts

### DIFF
--- a/src/Rare.js
+++ b/src/Rare.js
@@ -5,6 +5,7 @@ import { NavBar } from "./components/nav/NavBar";
 export const Rare = () => {
   const [token, setTokenState] = useState(localStorage.getItem("auth_token"));
   const staff = JSON.parse(localStorage.getItem("staff")); // should be a boolean value
+  const currentUserId = JSON.parse(localStorage.getItem("id"));
 
   const setToken = (newToken) => {
     localStorage.setItem("auth_token", newToken);
@@ -14,7 +15,12 @@ export const Rare = () => {
   return (
     <>
       <NavBar token={token} setToken={setToken} staff={staff} />
-      <ApplicationViews token={token} setToken={setToken} staff={staff} />
+      <ApplicationViews
+        token={token}
+        setToken={setToken}
+        staff={staff}
+        currentUserId={currentUserId}
+      />
     </>
   );
 };

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -21,6 +21,8 @@ export const Login = ({ setToken }) => {
         setToken(res.token);
         localStorage.setItem("staff", res.staff);
         navigate("/");
+        localStorage.setItem("id", res.id);
+        navigate("/");
       } else {
         setisUnsuccessful(true);
       }

--- a/src/components/posts/PostDetails.js
+++ b/src/components/posts/PostDetails.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { getPostById } from "../../managers/PostManager";
+import { deletePost, getPostById } from "../../managers/PostManager";
 
-export const PostDetails = ({ token }) => {
+export const PostDetails = ({ token, currentUserId }) => {
   const [post, setPost] = useState({});
 
   const { postId } = useParams();
@@ -13,6 +13,17 @@ export const PostDetails = ({ token }) => {
       setPost(postObj);
     });
   }, [token, postId]);
+
+  const handleDelete = (postId) => {
+    const confirmDelete = window.confirm(
+      "Are you sure you want to delete tag?"
+    );
+    if (confirmDelete) {
+      deletePost(token, postId).then(() => {
+        navigate(`/posts/mine`);
+      });
+    }
+  };
 
   return (
     <article className="columns is-centered mt-6">
@@ -27,6 +38,23 @@ export const PostDetails = ({ token }) => {
             <div className="content">{post.publication_date}</div>
           </div>
           <div className="content">{post.content}</div>
+          <div className="is-flex is-justify-content-end">
+            {currentUserId === post.rare_user?.user.id ? (
+              <>
+                <div className="tag--item">
+                  <i className="fa-solid fa-gear fa-lg"></i>
+                </div>
+                <div className="tag--item">
+                  <i
+                    className="fa-solid fa-trash-can fa-lg"
+                    onClick={() => handleDelete(post.id)}
+                  ></i>
+                </div>
+              </>
+            ) : (
+              ""
+            )}
+          </div>
         </div>
         <div className="field is-grouped is-grouped-centered mb-3">
           <div className="control">

--- a/src/components/tags/Tag.css
+++ b/src/components/tags/Tag.css
@@ -18,13 +18,3 @@
 .button--container {
   margin-right: 2rem;
 }
-
-.fa-trash-can:hover {
-  color: red;
-  cursor: pointer;
-}
-
-.fa-gear:hover {
-  color: hsl(141, 53%, 53%);
-  cursor: pointer;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,11 @@
 @import "bulma/css/bulma.css";
+
+.fa-trash-can:hover {
+  color: red;
+  cursor: pointer;
+}
+
+.fa-gear:hover {
+  color: hsl(141, 53%, 53%);
+  cursor: pointer;
+}

--- a/src/managers/PostManager.js
+++ b/src/managers/PostManager.js
@@ -24,3 +24,12 @@ export const getUserPosts = (token) => {
     },
   }).then((response) => response.json());
 };
+
+export const deletePost = (token, postId) => {
+  return fetch(`http://localhost:8000/posts/${postId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Token ${token}`,
+    },
+  });
+};

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -14,7 +14,13 @@ import { UpdateCategory } from "../components/categories/UpdateCategory";
 import { AllPosts } from "../components/posts/AllPosts";
 import { PostDetails } from "../components/posts/PostDetails";
 
-export const ApplicationViews = ({ token, setToken, staff, setStaff }) => {
+export const ApplicationViews = ({
+  token,
+  setToken,
+  staff,
+  setStaff,
+  currentUserId,
+}) => {
   return (
     <>
       <Routes>
@@ -30,7 +36,9 @@ export const ApplicationViews = ({ token, setToken, staff, setStaff }) => {
             <Route path="mine" element={<MyPosts token={token} />} />
             <Route
               path="details/:postId"
-              element={<PostDetails token={token} />}
+              element={
+                <PostDetails token={token} currentUserId={currentUserId} />
+              }
             />
           </Route>
           <Route path="categories">


### PR DESCRIPTION
I updated Post View to include the ability for an author to delete a post

## Steps to Test
1. Pull down `ts-delete-post` branch and switch to it and that your debugger is running
2. Be sure to pull down `ts-destroy-post` on the server side
3. Login with the following credentials or any in the system
```
{
        "username": "phifertristan",
        "password": "phifer"
}
```
4. Click on either All Post or My Post in the menu
5. Click on one of the current user's posts
6. You should see a gear icon and a trash icon next in the bottom right corner of the post
7. Click on a trash icon and you should see a window confirmation appear
8. Click on cancel and you should return to the post details page
9. Click on a trash icon again but this time click okay, you should be sent to the My Posts page with the post you deleted no longer showing up
10. In the network tab you should be receiving a 204 status code for the delete and a 200 for the re-rendering of the page.
11. Lastly, click on a different users post details, you should NOT see a gear or trash can.

closes #14 