### PR TITLE
Add Tags to Posts

### DIFF
--- a/src/components/posts/PostDetails.js
+++ b/src/components/posts/PostDetails.js
@@ -1,9 +1,14 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { deletePost, getPostById } from "../../managers/PostManager";
+import { getAllTags } from "../../managers/TagManager";
+import { createPostTag } from "../../managers/PostTagManager";
 
 export const PostDetails = ({ token, currentUserId }) => {
   const [post, setPost] = useState({});
+  const [tags, setTags] = useState({});
+  const [selectedTags, setSelectedTags] = useState([]);
+  const [showTagModal, setShowTagModal] = useState(false);
 
   const { postId } = useParams();
   const navigate = useNavigate();
@@ -14,6 +19,12 @@ export const PostDetails = ({ token, currentUserId }) => {
     });
   }, [token, postId]);
 
+  useEffect(() => {
+    getAllTags(token).then((tagsArray) => {
+      setTags(tagsArray);
+    });
+  }, [token]);
+
   const handleDelete = (postId) => {
     const confirmDelete = window.confirm(
       "Are you sure you want to delete tag?"
@@ -22,6 +33,43 @@ export const PostDetails = ({ token, currentUserId }) => {
       deletePost(token, postId).then(() => {
         navigate(`/posts/mine`);
       });
+    }
+  };
+
+  const openTagModal = () => {
+    setShowTagModal(true);
+  };
+
+  const closeTagModal = () => {
+    setShowTagModal(false);
+  };
+
+  const handleTagSelection = (tagId) => {
+    const updatedTags = [...selectedTags];
+    const index = updatedTags.indexOf(tagId);
+
+    if (index === -1) {
+      updatedTags.push(tagId);
+    } else {
+      updatedTags.splice(index, 1);
+    }
+    setSelectedTags(updatedTags);
+  };
+
+  const handleSaveTags = async () => {
+    try {
+      const promises = selectedTags.map((tagId) =>
+        createPostTag(postId, tagId, token)
+      );
+
+      await Promise.all(promises);
+
+      getPostById(postId, token).then((postObj) => {
+        setPost(postObj);
+      });
+      closeTagModal();
+    } catch (error) {
+      console.error("Error creating post tags:", error);
     }
   };
 
@@ -56,7 +104,26 @@ export const PostDetails = ({ token, currentUserId }) => {
             )}
           </div>
         </div>
+        <div className="content">
+          <strong>Associated Tags:</strong>
+          {post.post_tags && post.post_tags.length > 0 ? (
+            <ul>
+              {post.post_tags?.map((tag) => (
+                <li key={tag.id}>{tag.label}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>No tags associated with this post.</p>
+          )}
+        </div>
         <div className="field is-grouped is-grouped-centered mb-3">
+          {currentUserId === post.rare_user?.user.id && (
+            <div className="control">
+              <button className="button" onClick={openTagModal}>
+                Manage Tags
+              </button>
+            </div>
+          )}
           <div className="control">
             <button
               className="button is-warning"
@@ -79,6 +146,52 @@ export const PostDetails = ({ token, currentUserId }) => {
           </div>
         </div>
       </div>
+      {showTagModal && (
+        <div className="modal is-active">
+          <div
+            className="modal-background"
+            style={{ backgroundColor: "rgba(200, 160, 255, 0.4)" }}
+            onClick={closeTagModal}
+          ></div>
+          <div className="modal-content">
+            <div className="box">
+              <h3 className="title is-3">Manage Tags</h3>
+              <ul>
+                {tags.map((tag) => (
+                  <li key={tag.id}>
+                    <label>
+                      <input
+                        type="checkbox"
+                        value={tag.id}
+                        onChange={(e) => {
+                          const selectedTag = parseInt(e.target.value);
+                          handleTagSelection(selectedTag);
+                        }}
+                      />
+                      {tag.label}
+                    </label>
+                  </li>
+                ))}
+              </ul>
+              <div className="field is-grouped is-grouped-centered mt-3">
+                <div className="control">
+                  <button
+                    className="button is-success"
+                    onClick={handleSaveTags}
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            className="modal-close is-large"
+            aria-label="close"
+            onClick={closeTagModal}
+          ></button>
+        </div>
+      )}
     </article>
   );
 };

--- a/src/managers/PostTagManager.js
+++ b/src/managers/PostTagManager.js
@@ -1,0 +1,15 @@
+export const createPostTag = (postId, selectedTag, token) => {
+  const newPostTag = {
+    tag: selectedTag,
+    post: postId,
+  };
+
+  return fetch("http://localhost:8000/post_tags", {
+    method: "POST",
+    headers: {
+      Authorization: `Token ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(newPostTag),
+  });
+};


### PR DESCRIPTION
I updated Post Details View to include the ability for an author to associate tags with the post, and a list of associated tags to each post.

## Steps to Test
1. Pull down `tp-add-tags-to-posts` branch and switch to it and that your debugger is running
2. Be sure to pull down `tp-add-tag-to-post` on the server side
3. Login with the following credentials or any in the system
```
{
        "username": "phifertristan",
        "password": "phifer"
}
```
4. Click on either All Post or My Post in the menu
5. Click on one of the current user's posts
6. You should see a `Manage Tags` button next to the left of the `View Comments` button
7. Click on the `Manage Tags` button and a modal should overlay with a list of tags to check. Check whichever ones you want.
8. Clicking outside the modal will leave the modal, and any selections made will not be saved.
9. Clicking the `Save` button after having selections made will exit the modal, and you should see the tags you selected appear in the associated tags section.
10. In the network tab you should be receiving a 201 status code for the create of each tag selected and a 200 for the re-rendering of the page.
11. Lastly, click on a different users post details, you should NOT see the `Manage Tags` button